### PR TITLE
Improve startup info and add download summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ pip install -r requirements.txt
 Para iniciar rapidamente no macOS, basta **dar dois cliques** em `start.command`.
 Ele cria um ambiente virtual, instala as dependências e abre o navegador
 automaticamente. Em outros sistemas, execute `./run.sh` manualmente ou
-`python run_app.py`.
+`python run_app.py`. Esse script procura uma porta livre a partir da 5000 e abre
+o navegador no endereço encontrado.
 
 ## Uso
 
@@ -40,8 +41,9 @@ python setup_pyinstaller.py
 
 O executável `.exe` será criado em `dist/`.
 
-Abra o endereço exibido no terminal (por padrão `http://localhost:5000`; se a
-porta estiver em uso será escolhida a próxima disponível). Primeiro crie uma ou
-mais listas de perfis na tela **Listas**. Em seguida, em **Solicitar Relatório**,
-escolha a lista desejada, defina o período (com data e hora) e o formato do
-arquivo. O arquivo é oferecido para download automaticamente.
+Ao executar o aplicativo, o servidor Flask será iniciado e o navegador será
+aberto automaticamente no endereço disponível. Primeiro crie uma ou mais listas
+de perfis na tela **Listas**. Em seguida, em **Solicitar Relatório**, escolha a
+lista desejada, defina o período (com data e hora) e o formato do arquivo. O
+relatório é oferecido para download automaticamente e um resumo da coleta é
+exibido na própria página.

--- a/app.py
+++ b/app.py
@@ -158,6 +158,12 @@ def collect():
         if df.empty:
             return render_template('error.html', message='Nenhum tweet encontrado para o período selecionado.')
 
+        summary_lines = []
+        for user, count in df['usuario'].value_counts().items():
+            summary_lines.append(f"{user}: {count} links")
+        summary_lines.append(f"Total: {len(df)} tweets")
+        flash("; ".join(summary_lines), "success")
+
         if fmt == 'csv':
             buf = io.StringIO()
             df.to_csv(buf, index=False)

--- a/run_app.py
+++ b/run_app.py
@@ -17,5 +17,7 @@ def find_port(start=5000, limit=5100):
 
 if __name__ == "__main__":
     port = find_port()
-    webbrowser.open(f"http://127.0.0.1:{port}")
+    url = f"http://127.0.0.1:{port}"
+    print(f"Starting server on {url}")
+    webbrowser.open(url)
     app.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- show port info when starting the server
- display tweet collection summary via flash messages
- clarify the dynamic port on README and explain executable usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849b4ccb78c83259443c0bf1ecf3925