### PR TITLE
Implement dark mode and navigation updates

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,4 +1,6 @@
-body {background-color:#f5f5f5;}
-.card {box-shadow:0 2px 4px rgba(0,0,0,0.1); border-radius:6px;}
-.btn-primary {background-color:#1a237e; border-color:#1a237e;}
-.btn-primary:hover {background-color:#ff6f00; border-color:#ff6f00;}
+body {background-color:#121212; color:#fff;}
+.card {background-color:#1e1e1e; box-shadow:0 2px 4px rgba(0,0,0,0.5); border-radius:6px;}
+.btn-primary {background-color:#3949ab; border-color:#3949ab;}
+.btn-primary:hover {background-color:#5c6bc0; border-color:#5c6bc0;}
+.navbar {padding-top:1rem; padding-bottom:1rem;}
+.form-control, .form-select {background-color:#333; color:#fff; border-color:#555;}

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,10 +7,15 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
-<body class="bg-light">
-<nav class="navbar navbar-expand-lg" style="background-color:#1a237e;">
+<body class="bg-dark text-white">
+<nav class="navbar navbar-expand-lg navbar-dark" style="background-color:#1a237e;">
     <div class="container-fluid">
-        <a class="navbar-brand text-white" href="{{ url_for('index') }}">Tweet Collector</a>
+        <a class="navbar-brand" href="{{ url_for('index') }}">Tweet Collector</a>
+        <div class="d-flex">
+            <a class="btn btn-outline-light me-2" href="{{ url_for('index') }}">Home</a>
+            <a class="btn btn-outline-light me-2" href="{{ url_for('lists_view') }}">Listas</a>
+            <a class="btn btn-outline-light" href="{{ url_for('collect') }}">Relatório</a>
+        </div>
     </div>
 </nav>
 <div class="container py-4">

--- a/templates/collect.html
+++ b/templates/collect.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Coletar Tweets{% endblock %}
 {% block content %}
-<div class="card p-4 bg-white">
+<div class="card p-4 bg-dark text-white">
 <h1 class="h4 mb-4">Solicitar Relatório</h1>
 <form action="{{ url_for('collect') }}" method="post" id="collect-form">
     <div class="mb-3">
@@ -16,13 +16,11 @@
     <div class="mb-3 row">
         <div class="col">
             <label class="form-label">Início:</label>
-            <input type="date" name="start" value="{{ start_date or '' }}" class="form-control">
-            <input type="time" name="start_time" value="{{ start_time or '' }}" class="form-control mt-1">
+            <input type="datetime-local" name="start" value="{{ start or '' }}" class="form-control">
         </div>
         <div class="col">
             <label class="form-label">Fim:</label>
-            <input type="date" name="end" value="{{ end_date or '' }}" class="form-control">
-            <input type="time" name="end_time" value="{{ end_time or '' }}" class="form-control mt-1">
+            <input type="datetime-local" name="end" value="{{ end or '' }}" class="form-control">
         </div>
     </div>
     <div class="mb-3">
@@ -52,7 +50,6 @@
         <span id="spinner" class="spinner-border spinner-border-sm d-none" role="status"></span>
     </button>
 </form>
-<p class="mt-3"><a href="{{ url_for('lists_view', list=selected) }}" class="btn btn-secondary">Voltar às Listas</a></p>
 </div>
 <script>
 document.getElementById('collect-form').addEventListener('submit', function() {

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Erro{% endblock %}
 {% block content %}
-<div class="card p-4 bg-white text-center">
+<div class="card p-4 bg-dark text-white text-center">
     <h1 class="h4 mb-3">Ocorreu um problema</h1>
     <p>{{ message }}</p>
     <a href="{{ url_for('collect') }}" class="btn btn-secondary mt-2">Voltar</a>

--- a/templates/lists.html
+++ b/templates/lists.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Listas{% endblock %}
 {% block content %}
-<div class="card p-4 bg-white">
+<div class="card p-4 bg-dark text-white">
 <h1 class="h4 mb-4">Gerenciar Listas</h1>
 <form action="{{ url_for('lists_view') }}" method="post" class="mb-3 d-flex">
     <input type="hidden" name="action" value="add_list">
@@ -9,43 +9,47 @@
     <button type="submit" class="btn btn-primary">Criar Lista</button>
 </form>
 {% if lists %}
-<form method="get" action="{{ url_for('lists_view') }}" class="mb-3">
-    <label class="form-label">Selecionar lista:
-        <select name="list" onchange="this.form.submit()" class="form-select">
-            {% for l in lists %}
-            <option value="{{ l }}" {% if l == selected %}selected{% endif %}>{{ l }}</option>
+<div class="accordion" id="listsAccordion">
+{% for name, profiles in lists.items() %}
+<div class="accordion-item bg-dark text-white">
+    <h2 class="accordion-header" id="heading{{ loop.index }}">
+        <button class="accordion-button collapsed bg-dark text-white" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ loop.index }}" aria-expanded="{{ 'true' if name == selected else 'false' }}" aria-controls="collapse{{ loop.index }}">
+            {{ name }} ({{ profiles|length }} perfis)
+        </button>
+    </h2>
+    <div id="collapse{{ loop.index }}" class="accordion-collapse collapse {% if name == selected %}show{% endif %}" aria-labelledby="heading{{ loop.index }}" data-bs-parent="#listsAccordion">
+        <div class="accordion-body">
+            {% if profiles %}
+            <div class="mb-3">
+            {% for p in profiles %}
+                <form action="{{ url_for('lists_view', list=name) }}" method="post" class="d-inline">
+                    <input type="hidden" name="action" value="remove_profile">
+                    <input type="hidden" name="listname" value="{{ name }}">
+                    <input type="hidden" name="profile" value="{{ p }}">
+                    <span class="badge bg-secondary me-1 mb-1">
+                        @{{ p }}
+                        <button type="submit" class="btn-close btn-close-white btn-sm ms-1" aria-label="Remove"></button>
+                    </span>
+                </form>
             {% endfor %}
-        </select>
-    </label>
-</form>
-{% if selected %}
-<h2 class="h5">Perfis de {{ selected }}</h2>
-<ul class="list-group mb-3">
-    {% for p in profiles %}
-    <li class="list-group-item d-flex justify-content-between align-items-center">
-        @{{ p }}
-        <form action="{{ url_for('lists_view', list=selected) }}" method="post" class="ms-3">
-            <input type="hidden" name="action" value="remove_profile">
-            <input type="hidden" name="listname" value="{{ selected }}">
-            <input type="hidden" name="profile" value="{{ p }}">
-            <button type="submit" class="btn btn-sm btn-danger">Remover</button>
-        </form>
-    </li>
-    {% endfor %}
-</ul>
-<form action="{{ url_for('lists_view', list=selected) }}" method="post" class="d-flex mb-3">
-    <input type="hidden" name="action" value="add_profile">
-    <input type="hidden" name="listname" value="{{ selected }}">
-    <input type="text" name="profile" placeholder="novo perfil" class="form-control me-2">
-    <button type="submit" class="btn btn-primary">Adicionar</button>
-</form>
-<form action="{{ url_for('lists_view') }}" method="post" onsubmit="return confirm('Excluir esta lista?');" class="mb-3">
-    <input type="hidden" name="action" value="delete_list">
-    <input type="hidden" name="listname" value="{{ selected }}">
-    <button type="submit" class="btn btn-danger">Excluir lista</button>
-</form>
+            </div>
+            {% endif %}
+            <form action="{{ url_for('lists_view', list=name) }}" method="post" class="d-flex mb-3">
+                <input type="hidden" name="action" value="add_profile">
+                <input type="hidden" name="listname" value="{{ name }}">
+                <input type="text" name="profile" placeholder="novo perfil" class="form-control me-2">
+                <button type="submit" class="btn btn-primary">Adicionar</button>
+            </form>
+            <form action="{{ url_for('lists_view') }}" method="post" onsubmit="return confirm('Excluir esta lista?');" class="mb-3">
+                <input type="hidden" name="action" value="delete_list">
+                <input type="hidden" name="listname" value="{{ name }}">
+                <button type="submit" class="btn btn-danger">Excluir lista</button>
+            </form>
+        </div>
+    </div>
+</div>
+{% endfor %}
+</div>
 {% endif %}
-{% endif %}
-<p><a href="{{ url_for('collect', list=selected) }}" class="btn btn-primary">Solicitar Relatório</a></p>
 </div>
 {% endblock %}

--- a/templates/success.html
+++ b/templates/success.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Sucesso{% endblock %}
 {% block content %}
-<div class="card p-4 bg-white text-center">
+<div class="card p-4 bg-dark text-white text-center">
     <h1 class="h4 mb-3">Relatório gerado</h1>
     <p>Seu download deve iniciar em instantes. Caso não começe, <a href="{{ url }}">clique aqui</a>.</p>
 </div>


### PR DESCRIPTION
## Summary
- enable dark theme styling
- expand navbar with navigation links
- rework list management page with accordion lists
- simplify report date entry with datetime picker
- remove leftover white backgrounds

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6849d29bcf2c8325a7384bbb246b9818