### PR TITLE
Improve dark theme and download summary

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,6 +1,11 @@
-body {background-color:#121212; color:#fff;}
-.card {background-color:#1e1e1e; box-shadow:0 2px 4px rgba(0,0,0,0.5); border-radius:6px;}
+body {background-color:#121212; color:#e0e0e0;}
+.card {background-color:#1e1e1e; color:#e0e0e0; box-shadow:0 2px 4px rgba(0,0,0,0.5); border-radius:6px;}
 .btn-primary {background-color:#3949ab; border-color:#3949ab;}
 .btn-primary:hover {background-color:#5c6bc0; border-color:#5c6bc0;}
 .navbar {padding-top:1rem; padding-bottom:1rem;}
-.form-control, .form-select {background-color:#333; color:#fff; border-color:#555;}
+.form-control, .form-select {background-color:#333; color:#e0e0e0; border-color:#555;}
+.form-control:focus, .form-select:focus {background-color:#333; color:#e0e0e0;}
+.text-white {color:#e0e0e0 !important;}
+.btn-outline-light {color:#e0e0e0; border-color:#777;}
+.btn-outline-light:hover {color:#e0e0e0; background-color:#3949ab; border-color:#3949ab;}
+.navbar-dark .navbar-nav .nav-link {color:#e0e0e0;}

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,11 +11,11 @@
 <nav class="navbar navbar-expand-lg navbar-dark" style="background-color:#1a237e;">
     <div class="container-fluid">
         <a class="navbar-brand" href="{{ url_for('index') }}">Tweet Collector</a>
-        <div class="d-flex">
-            <a class="btn btn-outline-light me-2" href="{{ url_for('index') }}">Home</a>
-            <a class="btn btn-outline-light me-2" href="{{ url_for('lists_view') }}">Listas</a>
-            <a class="btn btn-outline-light" href="{{ url_for('collect') }}">Relatório</a>
-        </div>
+        <ul class="navbar-nav ms-2">
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('index') }}">Home</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('lists_view') }}">Listas</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="{{ url_for('collect') }}">Relatório</a></li>
+        </ul>
     </div>
 </nav>
 <div class="container py-4">

--- a/templates/success.html
+++ b/templates/success.html
@@ -3,6 +3,16 @@
 {% block content %}
 <div class="card p-4 bg-dark text-white text-center">
     <h1 class="h4 mb-3">Relatório gerado</h1>
-    <p>Seu download deve iniciar em instantes. Caso não começe, <a href="{{ url }}">clique aqui</a>.</p>
+    {% if summary %}
+    <p class="mb-3">
+        {% for line in summary %}
+            {{ line }}<br>
+        {% endfor %}
+    </p>
+    {% endif %}
+    <p>Seu download deve iniciar em instantes. Caso não comece, <a id="download-link" href="{{ url }}">clique aqui</a>.</p>
 </div>
+<script>
+document.getElementById('download-link').click();
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- tweak Bootstrap navbar layout
- refresh dark theme palette and remove pure white
- show summary and auto download after generating report
- store downloadable files temporarily in memory

## Testing
- `python -m py_compile app.py`
- `python -m py_compile run_app.py`
- `flake8 app.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849dffe552c83258a827ee222e28cdb