### PR TITLE
Fix install failure due to missing snscrape version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Esta aplicação web permite criar **listas de perfis** do Twitter e gerar relat
 pip install -r requirements.txt
 ```
 
-O arquivo `requirements.txt` já exige `snscrape >= 0.7.8`. Para contar com o
+O arquivo `requirements.txt` já exige `snscrape >= 0.7.0.20230622`. Para contar com o
 fallback via **Twint**, instale também:
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask
-snscrape>=0.7.8
+snscrape>=0.7.0.20230622
 pandas
 fpdf
 nest_asyncio


### PR DESCRIPTION
## Summary
- adjust `snscrape` version requirement so `pip install` succeeds
- update README accordingly

## Testing
- `bash run.sh` *(fails: AttributeError: 'FileFinder' object has no attribute 'find_module')*

------
https://chatgpt.com/codex/tasks/task_e_6849e42042e48325a994a7e6da21ef39